### PR TITLE
Prevent issues running on a LOCAL agent

### DIFF
--- a/DataOps-CI.yml
+++ b/DataOps-CI.yml
@@ -19,6 +19,7 @@ jobs:
   - task: PowerShell@2
     displayName: Continuous Integration
     inputs:
+      pwsh: true
       filePath: PipelineScripts/PremiumPerUser/Start-CI.ps1
     env:
       PPU_PASSWORD: $(PPU_PASSWORD) # Maps the secret variable

--- a/PipelineScripts/PremiumPerUser/Start-CI.ps1
+++ b/PipelineScripts/PremiumPerUser/Start-CI.ps1
@@ -4,10 +4,13 @@
 
     Dependencies: Premium Per User license purchased and assigned to UserName and UserName has admin right to workspace.
 #>
+#Force the load of the SqlServer module first to avoid Microsoft.Identity.Client DLL conflicts when running on a LOCAL agent
+$SqlServerVersion = (Get-InstalledModule | Where-Object name -eq SqlServer).Version
+Import-Module SqlServer -RequiredVersion $SqlServerVersion
 #Setup TLS 12
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 #Get Working Directory
-$WorkingDir = (& pwd) -replace "\\", '/'
+$WorkingDir = (& Get-Location) -replace "\\", '/'
 Import-Module $WorkingDir/PipelineScripts/PremiumPerUser/Publish-PBIFileWithPPU.psm1 -Force
 Import-Module $WorkingDir/PipelineScripts/PremiumPerUser/Invoke-RefreshDatasetSyncWithPPU.psm1 -Force
 Import-Module $WorkingDir/Pbi/TestingScripts/Pester/4.10.1/Pester.psm1 -Force
@@ -101,7 +104,7 @@ foreach($PBIPromote in $Opts.PbixTracking){
     Write-Host "Checking if file needs refreshing: $($PBIPromote.PBIPath)"
 
     #If DatasetId property is not null then this is a PowerBI report with a dataset needing a refresh
-    if($PBIPromote.BuildInfo.DatasetId -ne $null){
+    if($null -ne $PBIPromote.BuildInfo.DatasetId){
         $RefreshResult = Invoke-RefreshDatasetSyncWithPPU -WorkspaceId $Opts.BuildGroupId `
                         -DatasetId $PBIPromote.BuildInfo.DatasetId `
                         -UserName $Opts.UserName `


### PR DESCRIPTION
Running the Azure DevOps agent on an Azure VM with Windows 11, had to force the use of PowerShell 7 in the Yaml. In addition, the start CI process required that Microsoft loads the right and appropriate SqlServer version because others may exist from the OS. If this condition occurs, the conflicting DLLs would fail to load, resulting in an aborted pipeline with a generic "A connection cannot be made. Ensure that the server is running." error.